### PR TITLE
Update TransmissionRPC.class.php

### DIFF
--- a/class/TransmissionRPC.class.php
+++ b/class/TransmissionRPC.class.php
@@ -595,14 +595,14 @@ class TransmissionRPC
     $this->username = $username;
     $this->password = $password;
     
+    // Get the Transmission RPC_version
+    $this->rpc_version = self::sget()->arguments->rpc_version;
+    
     // Return As Array
     $this->return_as_array = $return_as_array;
     
     // Reset X-Transmission-Session-Id so we (re)fetch one
-    $this->session_id = null;
-
-    // Get the Transmission RPC_version
-    $this->rpc_version = self::sget()->arguments->rpc_version;
+    $this->session_id = null
   }
 }
 


### PR DESCRIPTION
moved rpc_version check before return_as_array inside the TransmissionRPC class constructor.
The program was attempting to obtain information from an object after it had been converted to a string.
