### PR TITLE
Fix empty download-dir generates error in v2.92

### DIFF
--- a/class/TransmissionRPC.class.php
+++ b/class/TransmissionRPC.class.php
@@ -252,7 +252,7 @@ class TransmissionRPC
    */
   public function add_file ( $torrent_location, $save_path = '', $extra_options = array() )
   {
-    $extra_options['download-dir'] = $save_path;
+    if(!empty($save_path)) $extra_options['download-dir'] = $save_path;
     $extra_options['filename'] = $torrent_location;
     
     return $this->request( "torrent-add", $extra_options );


### PR DESCRIPTION
In trasmission 2.92 API, if you specify an empty download-dir option in the torrent-add method the command will fail with a "directory is not an absolute path" error. So, if the save_path is not specified by the user, you shall not add a download-dir option.